### PR TITLE
Fix typos in lib.rs and stdlib.fc

### DIFF
--- a/lazer/solana/src/lib.rs
+++ b/lazer/solana/src/lib.rs
@@ -26,7 +26,7 @@ use {
     std::mem::size_of,
 };
 
-// rustfmt's unstable import merging feature breaks complilation.
+// rustfmt's unstable import merging feature breaks compilation.
 #[rustfmt::skip]
 use solana_program::entrypoint;
 

--- a/price_feeds/ton/send_usd/contracts/imports/stdlib.fc
+++ b/price_feeds/ton/send_usd/contracts/imports/stdlib.fc
@@ -631,7 +631,7 @@ int get_seed() impure asm "RANDSEED";
 ;;; Equivalent to randomize(cur_lt());.
 () randomize_lt() impure asm "LTIME" "ADDRAND";
 
-;;; Checks whether the data parts of two slices coinside
+;;; Checks whether the data parts of two slices coincide
 int equal_slices_bits(slice a, slice b) asm "SDEQ";
 ;;; Checks whether b is a null. Note, that FunC also has polymorphic null? built-in.
 int builder_null?(builder b) asm "ISNULL";


### PR DESCRIPTION
# Fix typos in lib.rs and stdlib.fc

### Changes Made:
- **lib.rs**: Corrected "complilation" to "compilation" in the comment about `rustfmt`.
- **stdlib.fc**: Corrected "coinside" to "coincide" in the comment about slice data comparison.

### Purpose:
Improved accuracy and clarity of comments in the codebase for better readability and understanding.
