### PR TITLE
ops(stellar): update Lazer verifier id to redeployed testnet contract

### DIFF
--- a/lazer/stellar/README.md
+++ b/lazer/stellar/README.md
@@ -40,7 +40,7 @@ deploy the verifier yourself:
 
 | Contract | Testnet address |
 | -------- | --------------- |
-| Pyth Lazer verifier | `CD2KMDOR274ZVPVVSDIBWNBLGAXJOHKJBQGNWYQHF3O6H767UOYJJYJZ` |
+| Pyth Lazer verifier | `CAYFT5JE3UQTKT4Q6ZOZK4FXVYVT6RE3MFC7STA4UB6WAEGBT65MRU52` |
 
 Configure a funded testnet identity once:
 
@@ -57,7 +57,7 @@ stellar contract deploy \
   --source deployer \
   --network testnet \
   -- \
-  --lazer CD2KMDOR274ZVPVVSDIBWNBLGAXJOHKJBQGNWYQHF3O6H767UOYJJYJZ \
+  --lazer CAYFT5JE3UQTKT4Q6ZOZK4FXVYVT6RE3MFC7STA4UB6WAEGBT65MRU52 \
   --feed_id 1 \
   --freshness_threshold_us 60000000
 ```


### PR DESCRIPTION
The Stellar testnet Lazer verifier was redeployed (see [[i-sqhbiwii]]) under the current Wormhole mainnet guardian set (index 7) with the new trusted-signer storage from [[i-rqicqgmp]]. Point `lazer/stellar/README.md` at the new verifier id `CAYFT5JE3UQTKT4Q6ZOZK4FXVYVT6RE3MFC7STA4UB6WAEGBT65MRU52` (replacing `CD2KMDOR…` in both the address table and the example `stellar contract deploy --lazer` invocation).

Out of scope per [[i-sqhbiwii]]: the example consumer's own deployed contract id is a throwaway from a different exercise and is left untouched.