### PR TITLE
feat(lazer/stellar): reject non-newer prices in example consumer

### DIFF
--- a/lazer/stellar/README.md
+++ b/lazer/stellar/README.md
@@ -10,7 +10,8 @@ integration on Stellar:
 1. **Verify** a signed Lazer update via the deployed `pyth-lazer-stellar` verifier contract.
 2. **Parse** the verified payload with the published
    [`pyth-lazer-stellar-sdk`](https://crates.io/crates/pyth-lazer-stellar-sdk).
-3. **Freshness-check** the feed's update timestamp against a deployment-configured threshold.
+3. **Freshness-check** the feed's update timestamp against a deployment-configured threshold, and
+   reject any update whose timestamp is not strictly newer than the stored price (monotonic updates).
 4. **Store / retrieve** the latest price for a single configured feed.
 
 This is an example, not a production library — it tracks exactly one feed and keeps only the most

--- a/lazer/stellar/src/error.rs
+++ b/lazer/stellar/src/error.rs
@@ -14,6 +14,7 @@ pub enum Error {
     PriceNotInitialized = 6,
     Overflow = 7,
     ParseError = 8,
+    PriceOutdated = 9,
 }
 
 impl From<ParseError> for Error {

--- a/lazer/stellar/src/lib.rs
+++ b/lazer/stellar/src/lib.rs
@@ -34,7 +34,8 @@ impl PythLazerExample {
     }
 
     /// Verify a signed Pyth Lazer update, check it is fresh, and store the
-    /// latest price for the configured feed.
+    /// latest price for the configured feed. Rejects the update if its feed
+    /// timestamp is not strictly newer than the currently stored price.
     pub fn update_price(env: Env, payload: Bytes) -> Result<(), Error> {
         let lazer = state::get_lazer(&env);
         let feed_id = state::get_feed_id(&env);
@@ -60,6 +61,15 @@ impl PythLazerExample {
         // skew) reads as age 0 rather than erroring.
         if now_us.saturating_sub(feed_ts_us) > freshness_threshold_us {
             return Err(Error::PriceStale);
+        }
+
+        // Never overwrite a newer price with an older one: the update's feed
+        // timestamp must strictly exceed the stored one. This keeps the stored
+        // price monotonic even if updates arrive out of order.
+        if let Some(stored) = state::get_latest_price(&env) {
+            if feed_ts_us <= stored.timestamp_us {
+                return Err(Error::PriceOutdated);
+            }
         }
 
         let price = feed.price.ok_or(Error::PriceMissing)?;


### PR DESCRIPTION
The Stellar example consumer contract now enforces a monotonic freshness check when updating the price: an update is rejected unless its feed timestamp is strictly greater than the currently stored price's timestamp.

Previously `update_price` would overwrite the stored price with any update that passed the age-based freshness threshold, so an out-of-order update carrying an older feed timestamp could clobber a newer stored price. The new check reads the currently stored price and returns a new `Error::PriceOutdated` (code 9) if the incoming feed timestamp is not strictly newer, leaving the stored price untouched.

- `lazer/stellar/src/lib.rs`: added the strictly-newer-timestamp guard before storing.
- `lazer/stellar/src/error.rs`: added the `PriceOutdated` error variant.
- `lazer/stellar/README.md`: documented the monotonic-update guarantee.

Verified from `lazer/stellar/`: `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo build --release --target wasm32v1-none` all pass.