### PR TITLE
ci: bump `actions/checkout` to v4 in ci-starknet

### DIFF
--- a/.github/workflows/ci-starknet.yml
+++ b/.github/workflows/ci-starknet.yml
@@ -16,7 +16,7 @@ jobs:
       run:
         working-directory: price_feeds/starknet/send_usd/contract
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Scarb
         uses: software-mansion/setup-scarb@v1
         with:


### PR DESCRIPTION
## Problem

`.github/workflows/ci-starknet.yml:19` is the only workflow in this repo still on `actions/checkout@v3`, which runs on the deprecated Node 16 runtime. The other eight workflows — `ci-lazer-anchor`, `ci-lazer-evm`, `ci-lazer-js`, `ci-lazer-publisher`, `ci-lazer-solana`, `ci-lazer-stellar`, `ci-lazer-sui-test` and `ci-pro-frontend-jwt-auth` — are all already on `@v4`.

## Fix

One line, bringing the last straggler in line with the rest of the repo.

## Verification

All 9 workflow files re-parsed as YAML after the change; `grep` confirms `@v4` is now the only checkout version in the repo.